### PR TITLE
fix: destroy custom exfil trigger gameObject only when needed

### DIFF
--- a/Components/InteractableExfilsSession.cs
+++ b/Components/InteractableExfilsSession.cs
@@ -31,7 +31,11 @@ namespace InteractableExfilsAPI.Components
             // destroy all triggers to avoid end of raid null refs
             foreach (var trigger in CustomExfilTriggers)
             {
-                GameObject.Destroy(trigger.gameObject);
+                if (!trigger.IsNullOrDestroyed())
+                {
+
+                    GameObject.Destroy(trigger.gameObject);
+                }
             }
         }
 


### PR DESCRIPTION
Last time I played, I saw a stacktrace related to the usage of this Destroy method. I think this is because other mods (or even SPT itself) already did some cleanup before.