### PR TITLE
feat: new RefreshPrompt + remember last selected prompt item

### DIFF
--- a/Components/InteractableExfilsSession.cs
+++ b/Components/InteractableExfilsSession.cs
@@ -71,7 +71,7 @@ namespace InteractableExfilsAPI.Components
             customExfilTriggerObject.transform.localScale = exfil.gameObject.transform.localScale;
             CustomExfilTrigger customExfilTrigger = customExfilTriggerObject.AddComponent<CustomExfilTrigger>();
 
-            customExfilTrigger.Init(exfil, exfilIsActiveToPlayer);
+            customExfilTrigger.Init(exfil, exfilIsActiveToPlayer, []);
             CustomExfilTriggers.Add(customExfilTrigger);
         }
 

--- a/Examples.cs
+++ b/Examples.cs
@@ -132,7 +132,7 @@ namespace InteractableExfilsAPI
                 () =>
                 {
                     Counter++;
-                    InteractableExfilsService.RefreshPrompt();
+                    customExfilTrigger.RefreshPrompt();
                 }
             );
             CustomExfilAction decreaseCounterAction = new CustomExfilAction(
@@ -141,7 +141,7 @@ namespace InteractableExfilsAPI
                 () =>
                 {
                     Counter--;
-                    InteractableExfilsService.RefreshPrompt();
+                    customExfilTrigger.RefreshPrompt();
                 }
             );
 

--- a/Examples.cs
+++ b/Examples.cs
@@ -20,7 +20,7 @@ namespace InteractableExfilsAPI
                 false,
                 () => { NotificationManagerClass.DisplayMessageNotification("Simple Intercation Example Selected!"); }
             );
-            
+
             return new OnActionsAppliedResult(customExfilAction);
         }
 
@@ -91,7 +91,7 @@ namespace InteractableExfilsAPI
                 false, // leave the action itself always enabled
                 () =>
                 {
-                    if ( !Settings.DebugMode.Value )
+                    if (!Settings.DebugMode.Value)
                     {
                         // check your disabled condition inside the action, and display a warning notif and an error sound if it isn't met followed by a return.
                         // this does a decent job of maintaining good player feedback so they know why the interaction didn't work, while allowing you to capture

--- a/Patches/GameStartedPatch.cs
+++ b/Patches/GameStartedPatch.cs
@@ -1,14 +1,8 @@
 ﻿using Comfort.Common;
 using EFT;
 using InteractableExfilsAPI.Components;
-using InteractableExfilsAPI.Singletons;
 using SPT.Reflection.Patching;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace InteractableExfilsAPI.Patches
 {

--- a/Patches/GetAvailableActionsPatch.cs
+++ b/Patches/GetAvailableActionsPatch.cs
@@ -1,18 +1,12 @@
-﻿using Comfort.Common;
-using EFT;
+﻿using EFT;
 using EFT.Interactive;
+using EFT.UI;
 using HarmonyLib;
-using InteractableExfilsAPI.Common;
 using InteractableExfilsAPI.Components;
 using InteractableExfilsAPI.Singletons;
 using SPT.Reflection.Patching;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-using UnityEngine;
 
 namespace InteractableExfilsAPI.Patches
 {
@@ -52,10 +46,11 @@ namespace InteractableExfilsAPI.Patches
             if (isCarExtract || isElevatorSwitch)
             {
                 ExfiltrationPoint exfil = GetExfilPointFromInteractive(interactive);
+                List<ActionsTypesClass> vanillaActions = GetVanillaInteractionActions(owner, interactive);
+                CustomExfilTrigger customTrigger = CreateCustomExfilTrigger(exfil, vanillaActions);
+                ActionsReturnClass prompt = customTrigger.CreateExfilPrompt();
 
-                __result = GetActionsClassWithCustomActions(exfil);
-                __result.Actions.AddRange(GetVanillaInteractionActions(owner, interactive));
-
+                __result = prompt;
                 return false;
             }
 
@@ -102,14 +97,18 @@ namespace InteractableExfilsAPI.Patches
             return vanillaExfilActions ?? [];
         }
 
-        private static ActionsReturnClass GetActionsClassWithCustomActions(ExfiltrationPoint exfil)
+        private static CustomExfilTrigger CreateCustomExfilTrigger(ExfiltrationPoint exfil, List<ActionsTypesClass> vanillaActions)
         {
             bool exfilIsActiveToPlayer = true;
             var customTrigger = new CustomExfilTrigger();
             customTrigger.Awake();
-            customTrigger.Init(exfil, exfilIsActiveToPlayer);
+            customTrigger.Init(exfil, exfilIsActiveToPlayer, vanillaActions);
 
-            return customTrigger.CreateExfilPrompt();
+            string message = $"GetActionsClassWithCustomActions called for exfil {exfil.Settings.Name}!\n";
+            ConsoleScreen.Log(message);
+            Plugin.LogSource.LogInfo(message);
+
+            return customTrigger;
         }
     }
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -32,15 +32,13 @@ namespace InteractableExfilsAPI
 
         private void Start()
         {
-            //Singleton<InteractableExfilsService>.Instance.OnActionsAppliedEvent += Examples.SimpleExample;
-            //Singleton<InteractableExfilsService>.Instance.OnActionsAppliedEvent += Examples.GoneWhenDisabledExample;
-            //Singleton<InteractableExfilsService>.Instance.OnActionsAppliedEvent += Examples.DynamicDisabledExample;
-            //Singleton<InteractableExfilsService>.Instance.OnActionsAppliedEvent += Examples.SoftDynamicDisabledExample;
-            //Singleton<InteractableExfilsService>.Instance.OnActionsAppliedEvent += Examples.ScavGate3OnlyExample;
-            //Singleton<InteractableExfilsService>.Instance.OnActionsAppliedEvent += Examples.RequiresManualActivationsGate3Example;
-            //Singleton<InteractableExfilsService>.Instance.OnActionsAppliedEvent += Examples.PromptRefreshingExample;
+            // Singleton<InteractableExfilsService>.Instance.OnActionsAppliedEvent += Examples.SimpleExample;
+            // Singleton<InteractableExfilsService>.Instance.OnActionsAppliedEvent += Examples.GoneWhenDisabledExample;
+            // Singleton<InteractableExfilsService>.Instance.OnActionsAppliedEvent += Examples.DynamicDisabledExample;
+            // Singleton<InteractableExfilsService>.Instance.OnActionsAppliedEvent += Examples.SoftDynamicDisabledExample;
+            // Singleton<InteractableExfilsService>.Instance.OnActionsAppliedEvent += Examples.ScavGate3OnlyExample;
+            // Singleton<InteractableExfilsService>.Instance.OnActionsAppliedEvent += Examples.RequiresManualActivationsGate3Example;
+            // Singleton<InteractableExfilsService>.Instance.OnActionsAppliedEvent += Examples.PromptRefreshingExample;
         }
-
-
     }
 }

--- a/Singletons/InteractableExfilsService.cs
+++ b/Singletons/InteractableExfilsService.cs
@@ -6,13 +6,9 @@ using HarmonyLib;
 using InteractableExfilsAPI.Common;
 using InteractableExfilsAPI.Components;
 using InteractableExfilsAPI.Helpers;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-using UnityEngine;
 
 namespace InteractableExfilsAPI.Singletons
 {
@@ -55,7 +51,6 @@ namespace InteractableExfilsAPI.Singletons
         // other mods can subscribe to this event and optionally pass ActionsTypesClass(es) back to be added to the interactable objects
         public event ActionsAppliedEventHandler OnActionsAppliedEvent;
         private FieldInfo _exfilPlayersMetAllRequirementsFieldInfo = AccessTools.Field(typeof(ExfiltrationPoint), "_playersMetAllRequirements");
-        internal static CustomExfilTrigger LatestCustomExfilTrigger { get; set; }
 
         public virtual OnActionsAppliedResult OnActionsApplied(ExfiltrationPoint exfil, CustomExfilTrigger customExfilTrigger, bool exfilIsAvailableToPlayer)
         {
@@ -149,19 +144,18 @@ namespace InteractableExfilsAPI.Singletons
             return session;
         }
 
+        /// <summary>
+        /// Deprecated: use CustomExfilTrigger.RefreshPrompt() instead
+        /// </summary>
         public static void RefreshPrompt()
         {
-            if (LatestCustomExfilTrigger != null)
-            {
-                LatestCustomExfilTrigger.UpdateExfilPrompt();
-            }
-            else
-            {
-                GetSession().PlayerOwner.ClearInteractionState();
-                string warnMsg = "InteractableExfilsService.RefreshPrompt called but player interaction state has been cleared";
-                Plugin.LogSource.LogWarning(warnMsg);
-                ConsoleScreen.LogWarning(warnMsg);
-            }
+            GetSession().PlayerOwner.ClearInteractionState();
+
+            string deprecationMessage = "InteractableExfilsService.RefreshPrompt is deprecated, prefer using InteractableExfilsService.RefreshPrompt";
+            Plugin.LogSource.LogWarning(deprecationMessage);
+            ConsoleScreen.LogWarning(deprecationMessage);
+            NotificationManagerClass.DisplayMessageNotification(deprecationMessage);
+
         }
 
         public static bool ExfilHasRequirement(ExfiltrationPoint exfil, ERequirementState requirement)

--- a/Singletons/InteractableExfilsService.cs
+++ b/Singletons/InteractableExfilsService.cs
@@ -55,6 +55,7 @@ namespace InteractableExfilsAPI.Singletons
         // other mods can subscribe to this event and optionally pass ActionsTypesClass(es) back to be added to the interactable objects
         public event ActionsAppliedEventHandler OnActionsAppliedEvent;
         private FieldInfo _exfilPlayersMetAllRequirementsFieldInfo = AccessTools.Field(typeof(ExfiltrationPoint), "_playersMetAllRequirements");
+        internal static CustomExfilTrigger LatestCustomExfilTrigger { get; set; }
 
         public virtual OnActionsAppliedResult OnActionsApplied(ExfiltrationPoint exfil, CustomExfilTrigger customExfilTrigger, bool exfilIsAvailableToPlayer)
         {
@@ -150,7 +151,17 @@ namespace InteractableExfilsAPI.Singletons
 
         public static void RefreshPrompt()
         {
-            GetSession().PlayerOwner.ClearInteractionState();
+            if (LatestCustomExfilTrigger != null)
+            {
+                LatestCustomExfilTrigger.UpdateExfilPrompt();
+            }
+            else
+            {
+                GetSession().PlayerOwner.ClearInteractionState();
+                string warnMsg = "InteractableExfilsService.RefreshPrompt called but player interaction state has been cleared";
+                Plugin.LogSource.LogWarning(warnMsg);
+                ConsoleScreen.LogWarning(warnMsg);
+            }
         }
 
         public static bool ExfilHasRequirement(ExfiltrationPoint exfil, ERequirementState requirement)
@@ -187,7 +198,6 @@ namespace InteractableExfilsAPI.Singletons
         {
             if (!Settings.InactiveExtractsDisplayUnavailable.Value) return null;
             if (exfilIsAvailableToPlayer) return null;
-            if (customExfilTrigger == null) return null; // exfil is car or labs elevator or other extract we aren't making a trigger for
 
             CustomExfilAction customExfilAction = new CustomExfilAction(
                 "Extract Unavailable",
@@ -201,7 +211,6 @@ namespace InteractableExfilsAPI.Singletons
         public OnActionsAppliedResult ApplyExtractToggleAction(ExfiltrationPoint exfil, CustomExfilTrigger customExfilTrigger, bool exfilIsAvailableToPlayer)
         {
             if (!exfilIsAvailableToPlayer) return null;
-            if (customExfilTrigger == null) return null; // exfil is car or labs elevator or other extract we aren't making a trigger for
 
             CustomExfilAction customExfilAction = GetExfilToggleAction(customExfilTrigger);
 


### PR DESCRIPTION
## Changes
- when (re)creating actions, check if there is already an `AvailableInteractionState` and try to retrieve the selected action
- introduce new `CustomExfilTrigger.RefreshPrompt` method that will re-create actions
- deprecate `InteractableExfilsService.RefreshPrompt` because it reset the selected item (still usable but will warn the player)
- instanciate a dummy `CustomExfilTrigger` that will be used for labs/cars exfils (so prompt can be refresh here too)
- some cleanup
