### PR TITLE
feat: add IsFirstRender static method

### DIFF
--- a/Examples.cs
+++ b/Examples.cs
@@ -126,6 +126,13 @@ namespace InteractableExfilsAPI
         public static int Counter = 1;
         public static OnActionsAppliedResult PromptRefreshingExample(ExfiltrationPoint exfil, CustomExfilTrigger customExfilTrigger, bool exfilIsAvailableToPlayer)
         {
+            // reset the counter when the prompt is rendered for the first time
+            // you can remove this if you want to keep the state of the Counter shared between multiple exfils
+            if (InteractableExfilsService.IsFirstRender())
+            {
+                Counter = 1;
+            }
+
             CustomExfilAction increaseCounterAction = new CustomExfilAction(
                 $"Increase Counter: {Counter}",
                 false,

--- a/Singletons/InteractableExfilsService.cs
+++ b/Singletons/InteractableExfilsService.cs
@@ -76,6 +76,11 @@ namespace InteractableExfilsAPI.Singletons
             return Singleton<InteractableExfilsService>.Instance;
         }
 
+        public static bool IsFirstRender()
+        {
+            return GetSession().PlayerOwner.AvailableInteractionState.Value == null;
+        }
+
         public static CustomExfilAction GetDebugAction(ExfiltrationPoint exfil)
         {
             return new CustomExfilAction(


### PR DESCRIPTION
This will allow to (re)initialize a prompt local state (like in the counter example)

- **feat: add InteractableExfilsService.IsFirstRender method**
- **docs: update the counter example to show how to reset it**
