### PR TITLE
Update to SPT 4.1

### DIFF
--- a/Common/CustomExfilAction.cs
+++ b/Common/CustomExfilAction.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using EFT.UI;
+using System;
 using System.Collections.Generic;
 
 namespace InteractableExfilsAPI.Common
@@ -44,9 +45,9 @@ namespace InteractableExfilsAPI.Common
             Action = action;
         }
 
-        public ActionsTypesClass GetActionsTypesClass()
+        public InteractionAction GetInteractionAction()
         {
-            return new ActionsTypesClass
+            return new InteractionAction
             {
                 Action = Action,
                 Name = GetName(),
@@ -54,16 +55,16 @@ namespace InteractableExfilsAPI.Common
             };
         }
 
-        public static List<ActionsTypesClass> GetActionsTypesClassList(List<CustomExfilAction> CustomExfilActionList)
+        public static List<InteractionAction> GetInteractionActionList(List<CustomExfilAction> CustomExfilActionList)
         {
-            List<ActionsTypesClass> actionsTypesClassList = new List<ActionsTypesClass>();
+            List<InteractionAction> interactionActionList = new List<InteractionAction>();
 
             foreach (CustomExfilAction CustomExfilAction in CustomExfilActionList)
             {
-                actionsTypesClassList.Add(CustomExfilAction.GetActionsTypesClass());
+                interactionActionList.Add(CustomExfilAction.GetInteractionAction());
             }
 
-            return actionsTypesClassList;
+            return interactionActionList;
         }
     }
 

--- a/Components/CustomExfilTrigger.cs
+++ b/Components/CustomExfilTrigger.cs
@@ -1,5 +1,6 @@
 ﻿using Comfort.Common;
 using EFT;
+using EFT.Communications;
 using EFT.Interactive;
 using EFT.UI;
 using HarmonyLib;
@@ -26,7 +27,7 @@ namespace InteractableExfilsAPI.Components
         // this is used to forbid the usage of the RefreshPrompt feature in the handler (to avoid infinite loop)
         internal bool LockedRefreshPrompt { get; set; } = false;
 
-        private List<ActionsTypesClass> VanillaBaseActions { get; set; } = [];
+        private List<InteractionAction> VanillaBaseActions { get; set; } = [];
         private bool _playerInTriggerArea = false;
 
         private InteractableExfilsSession _session;
@@ -102,7 +103,7 @@ namespace InteractableExfilsAPI.Components
             {
                 string tips = string.Join(", ", Exfil.GetTips(_session.MainPlayer.ProfileId));
                 ConsoleScreen.Log($"You have not met the extract requirements for {Exfil.Settings.Name}!");
-                NotificationManagerClass.DisplayWarningNotification($"{tips}");
+                NotificationManager.DisplayWarningNotification($"{tips}");
                 Singleton<GUISounds>.Instance.PlayUISound(EUISoundType.ErrorMessage);
                 return;
             }
@@ -132,16 +133,16 @@ namespace InteractableExfilsAPI.Components
             }
         }
 
-        internal void Init(ExfiltrationPoint exfil, bool exfilIsActiveToPlayer, List<ActionsTypesClass> vanillaBaseActions)
+        internal void Init(ExfiltrationPoint exfil, bool exfilIsActiveToPlayer, List<InteractionAction> vanillaBaseActions)
         {
             Exfil = exfil;
             ExfilIsActiveToPlayer = exfilIsActiveToPlayer;
             VanillaBaseActions = vanillaBaseActions;
         }
 
-        internal ActionsReturnClass CreateExfilPrompt()
+        internal AvailableInteractionState CreateExfilPrompt()
         {
-            ActionsReturnClass actionsReturn = _session.PlayerOwner.AvailableInteractionState.Value;
+            AvailableInteractionState actionsReturn = _session.PlayerOwner.AvailableInteractionState.Value;
 
             var selectedActionIndex = 0;
             if (actionsReturn != null)
@@ -164,9 +165,9 @@ namespace InteractableExfilsAPI.Components
                 OnExitZone = eventResult.OnExitZone;
             }
 
-            var actions = VanillaBaseActions.Concat(CustomExfilAction.GetActionsTypesClassList(eventResult.Actions)).ToList();
+            var actions = VanillaBaseActions.Concat(CustomExfilAction.GetInteractionActionList(eventResult.Actions)).ToList();
 
-            var newActionsReturn = new ActionsReturnClass { Actions = actions };
+            var newActionsReturn = new AvailableInteractionState { Actions = actions };
             int nbActions = actions.Count;
 
             if (nbActions == 0)
@@ -189,7 +190,7 @@ namespace InteractableExfilsAPI.Components
         {
             if (forceCreation || _session.PlayerOwner.AvailableInteractionState.Value != null)
             {
-                ActionsReturnClass exfilPrompt = CreateExfilPrompt();
+                AvailableInteractionState exfilPrompt = CreateExfilPrompt();
                 _session.PlayerOwner.AvailableInteractionState.Value = exfilPrompt;
             }
         }

--- a/Examples.cs
+++ b/Examples.cs
@@ -2,6 +2,7 @@
 using EFT;
 using InteractableExfilsAPI.Common;
 using InteractableExfilsAPI.Singletons;
+using EFT.Communications;
 using EFT.UI;
 using InteractableExfilsAPI.Helpers;
 using Comfort.Common;
@@ -18,7 +19,7 @@ namespace InteractableExfilsAPI
             CustomExfilAction customExfilAction = new CustomExfilAction(
                 "Example Interaction",
                 false,
-                () => { NotificationManagerClass.DisplayMessageNotification("Simple Interaction Example Selected!"); }
+                () => { NotificationManager.DisplayMessageNotification("Simple Interaction Example Selected!"); }
             );
 
             return new OnActionsAppliedResult(customExfilAction);
@@ -41,7 +42,7 @@ namespace InteractableExfilsAPI
             CustomExfilAction customExfilAction = new CustomExfilAction(
                 "Example Scav Only Gate 3 Interaction",
                 false,
-                () => { NotificationManagerClass.DisplayMessageNotification($"Simple Interaction Example Selected by profile: {player.ProfileId}"); }
+                () => { NotificationManager.DisplayMessageNotification($"Simple Interaction Example Selected by profile: {player.ProfileId}"); }
             );
 
             return new OnActionsAppliedResult(customExfilAction);
@@ -54,7 +55,7 @@ namespace InteractableExfilsAPI
             CustomExfilAction customExfilAction = new CustomExfilAction(
                 "I'm only active when Debug Mode is on (hard disable)",
                 !Settings.DebugMode.Value,
-                () => { NotificationManagerClass.DisplayMessageNotification("Dynamic Disabled Example (hard) Selected!"); }
+                () => { NotificationManager.DisplayMessageNotification("Dynamic Disabled Example (hard) Selected!"); }
             );
 
             return new OnActionsAppliedResult(customExfilAction);
@@ -70,7 +71,7 @@ namespace InteractableExfilsAPI
             CustomExfilAction customExfilAction = new CustomExfilAction(
                 "I'm only present in the interactions menu when enabled!",
                 false, // leave interaction enabled, we just won't add it at all when it's disabled state is met
-                () => { NotificationManagerClass.DisplayMessageNotification("Gone When Disabled Selected!"); }
+                () => { NotificationManager.DisplayMessageNotification("Gone When Disabled Selected!"); }
             );
 
             return new OnActionsAppliedResult(customExfilAction);
@@ -89,12 +90,12 @@ namespace InteractableExfilsAPI
                         // this does a decent job of maintaining good player feedback so they know why the interaction didn't work, while allowing you to capture
                         // the timing of the moment when the player selects the interaction.
                         // NOTE: this is exactly how the built in "Extract" toggle action itself is set up.
-                        NotificationManagerClass.DisplayWarningNotification("Debug mode not enabled!");
+                        NotificationManager.DisplayWarningNotification("Debug mode not enabled!");
                         Singleton<GUISounds>.Instance.PlayUISound(EUISoundType.ErrorMessage);
                         return;
                     }
 
-                    NotificationManagerClass.DisplayMessageNotification("Dynamic Disabled Example (soft) Selected!");
+                    NotificationManager.DisplayMessageNotification("Dynamic Disabled Example (soft) Selected!");
                 }
             );
 

--- a/Patches/GetAvailableActionsPatch.cs
+++ b/Patches/GetAvailableActionsPatch.cs
@@ -19,27 +19,35 @@ namespace InteractableExfilsAPI.Patches
         protected override MethodBase GetTargetMethod()
         {
             _getExfiltrationActions = AccessTools.FirstMethod(
-                typeof(GetActionsClass),
+                typeof(InteractionContextHelper),
                 method =>
+                method.GetParameters().Length >= 2 &&
                 method.GetParameters()[0].Name == "owner" &&
                 method.GetParameters()[1].ParameterType == typeof(ExfiltrationPoint)
             );
 
             _getSwitchActions = AccessTools.FirstMethod(
-                typeof(GetActionsClass),
+                typeof(InteractionContextHelper),
                 method =>
+                method.GetParameters().Length >= 2 &&
                 method.GetParameters()[0].Name == "owner" &&
                 method.GetParameters()[1].ParameterType == typeof(Switch)
             );
 
-            return AccessTools.FirstMethod(typeof(GetActionsClass), method => method.Name == nameof(GetActionsClass.GetAvailableActions) && method.GetParameters()[0].Name == "owner");
+            return AccessTools.FirstMethod(
+                typeof(InteractionContextHelper),
+                method =>
+                method.Name == nameof(InteractionContextHelper.GetAvailableActions) &&
+                method.GetParameters().Length >= 1 &&
+                method.GetParameters()[0].Name == "owner"
+            );
         }
 
         [PatchPrefix]
-        protected static bool PatchPrefix(object[] __args, ref ActionsReturnClass __result)
+        protected static bool PatchPrefix(object[] __args, ref AvailableInteractionState __result)
         {
             var owner = __args[0] as GamePlayerOwner;
-            var interactive = __args[1]; // as GInterface139 as of SPT 3.10.3
+            var interactive = __args[1]; // as EFT.IInteractive as of SPT 4.1
 
             if (IsInteractableExfil(interactive))
             {
@@ -50,9 +58,9 @@ namespace InteractableExfilsAPI.Patches
                     return true;
                 }
 
-                List<ActionsTypesClass> vanillaActions = GetVanillaInteractionActions(owner, interactive);
+                List<InteractionAction> vanillaActions = GetVanillaInteractionActions(owner, interactive);
                 CustomExfilTrigger customTrigger = CreateCustomExfilTrigger(exfil, vanillaActions);
-                ActionsReturnClass prompt = customTrigger.CreateExfilPrompt();
+                AvailableInteractionState prompt = customTrigger.CreateExfilPrompt();
 
                 __result = prompt;
                 return false;
@@ -88,7 +96,7 @@ namespace InteractableExfilsAPI.Patches
             return null;
         }
 
-        private static List<ActionsTypesClass> GetVanillaInteractionActions(GamePlayerOwner gamePlayerOwner, object interactive)
+        private static List<InteractionAction> GetVanillaInteractionActions(GamePlayerOwner gamePlayerOwner, object interactive)
         {
             if (InteractableExfilsService.Instance().DisableVanillaActions)
             {
@@ -107,11 +115,11 @@ namespace InteractableExfilsAPI.Patches
                 methodInfo = _getSwitchActions;
             }
 
-            List<ActionsTypesClass> vanillaExfilActions = ((ActionsReturnClass)methodInfo.Invoke(null, args))?.Actions;
+            List<InteractionAction> vanillaExfilActions = ((AvailableInteractionState)methodInfo.Invoke(null, args))?.Actions;
             return vanillaExfilActions ?? [];
         }
 
-        private static CustomExfilTrigger CreateCustomExfilTrigger(ExfiltrationPoint exfil, List<ActionsTypesClass> vanillaActions)
+        private static CustomExfilTrigger CreateCustomExfilTrigger(ExfiltrationPoint exfil, List<InteractionAction> vanillaActions)
         {
             // Create a new GameObject to attach the MonoBehaviour
             GameObject customTriggerObject = new GameObject("CustomExfilTrigger");
@@ -122,7 +130,7 @@ namespace InteractableExfilsAPI.Patches
             bool exfilIsActiveToPlayer = true;
             customTrigger.Init(exfil, exfilIsActiveToPlayer, vanillaActions);
 
-            string message = $"GetActionsClassWithCustomActions called for exfil {exfil.Settings.Name}!\n";
+            string message = $"InteractionContextHelper.GetAvailableActions patched for exfil {exfil.Settings.Name}!\n";
             ConsoleScreen.Log(message);
             Plugin.LogSource.LogInfo(message);
 

--- a/Patches/GetAvailableActionsPatch.cs
+++ b/Patches/GetAvailableActionsPatch.cs
@@ -1,10 +1,10 @@
 ﻿using EFT;
 using EFT.Interactive;
 using EFT.UI;
-using HarmonyLib;
 using InteractableExfilsAPI.Components;
 using InteractableExfilsAPI.Singletons;
 using SPT.Reflection.Patching;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using UnityEngine;
@@ -13,42 +13,16 @@ namespace InteractableExfilsAPI.Patches
 {
     internal class GetAvailableActionsPatch : ModulePatch
     {
-        private static MethodInfo _getExfiltrationActions;
-        private static MethodInfo _getSwitchActions;
-
         protected override MethodBase GetTargetMethod()
         {
-            _getExfiltrationActions = AccessTools.FirstMethod(
-                typeof(InteractionContextHelper),
-                method =>
-                method.GetParameters().Length >= 2 &&
-                method.GetParameters()[0].Name == "owner" &&
-                method.GetParameters()[1].ParameterType == typeof(ExfiltrationPoint)
-            );
-
-            _getSwitchActions = AccessTools.FirstMethod(
-                typeof(InteractionContextHelper),
-                method =>
-                method.GetParameters().Length >= 2 &&
-                method.GetParameters()[0].Name == "owner" &&
-                method.GetParameters()[1].ParameterType == typeof(Switch)
-            );
-
-            return AccessTools.FirstMethod(
-                typeof(InteractionContextHelper),
-                method =>
-                method.Name == nameof(InteractionContextHelper.GetAvailableActions) &&
-                method.GetParameters().Length >= 1 &&
-                method.GetParameters()[0].Name == "owner"
-            );
+            // Delegate cast resolves at compile time, build errors rather than runtime surprises.
+            return ((Func<GamePlayerOwner, IInteractive, AvailableInteractionState>)
+                InteractionContextHelper.GetAvailableActions).Method;
         }
 
         [PatchPrefix]
-        protected static bool PatchPrefix(object[] __args, ref AvailableInteractionState __result)
+        protected static bool PatchPrefix(GamePlayerOwner owner, IInteractive interactive, ref AvailableInteractionState __result)
         {
-            var owner = __args[0] as GamePlayerOwner;
-            var interactive = __args[1]; // as EFT.IInteractive as of SPT 4.1
-
             if (IsInteractableExfil(interactive))
             {
                 ExfiltrationPoint exfil = GetExfilPointFromInteractive(interactive);
@@ -70,7 +44,7 @@ namespace InteractableExfilsAPI.Patches
         }
 
         // vanilla interactable exfils (elevator exfils and saferoom exfil)
-        private static bool IsInteractableExfil(object interactive)
+        private static bool IsInteractableExfil(IInteractive interactive)
         {
             // 1. check for car exfils
             if (interactive is ExfiltrationPoint point)
@@ -88,7 +62,7 @@ namespace InteractableExfilsAPI.Patches
             return false;
         }
 
-        private static ExfiltrationPoint GetExfilPointFromInteractive(object interactive)
+        private static ExfiltrationPoint GetExfilPointFromInteractive(IInteractive interactive)
         {
             if (interactive is Switch @switch) return @switch.ExfiltrationPoint;
             if (interactive is ExfiltrationPoint point) return point;
@@ -96,27 +70,21 @@ namespace InteractableExfilsAPI.Patches
             return null;
         }
 
-        private static List<InteractionAction> GetVanillaInteractionActions(GamePlayerOwner gamePlayerOwner, object interactive)
+        private static List<InteractionAction> GetVanillaInteractionActions(GamePlayerOwner gamePlayerOwner, IInteractive interactive)
         {
             if (InteractableExfilsService.Instance().DisableVanillaActions)
             {
                 return [];
             }
 
-            object[] args = [gamePlayerOwner, interactive];
-
-            MethodInfo methodInfo = null;
-            if (interactive is ExfiltrationPoint)
+            AvailableInteractionState vanillaActions = interactive switch
             {
-                methodInfo = _getExfiltrationActions;
-            }
-            if (interactive is Switch)
-            {
-                methodInfo = _getSwitchActions;
-            }
+                ExfiltrationPoint point => InteractionContextHelper.GetAvailableActions(gamePlayerOwner, point),
+                Switch @switch => InteractionContextHelper.GetAvailableActions(gamePlayerOwner, @switch),
+                _ => null,
+            };
 
-            List<InteractionAction> vanillaExfilActions = ((AvailableInteractionState)methodInfo.Invoke(null, args))?.Actions;
-            return vanillaExfilActions ?? [];
+            return vanillaActions?.Actions ?? [];
         }
 
         private static CustomExfilTrigger CreateCustomExfilTrigger(ExfiltrationPoint exfil, List<InteractionAction> vanillaActions)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ public static class Examples
             isDisabled,
             () => {
                 // This part of the code is ran when the player interact with this prompt item
-                NotificationManagerClass.DisplayMessageNotification("Simple Interaction Example Selected!");
+                NotificationManager.DisplayMessageNotification("Simple Interaction Example Selected!");
             }
         );
 

--- a/Singletons/InteractableExfilsService.cs
+++ b/Singletons/InteractableExfilsService.cs
@@ -1,4 +1,5 @@
 ﻿using Comfort.Common;
+using Diz.Binding;
 using EFT;
 using EFT.Interactive;
 using EFT.UI;
@@ -63,7 +64,7 @@ namespace InteractableExfilsAPI.Singletons
 
     public class InteractableExfilsService
     {
-        // other mods can subscribe to this event and optionally pass ActionsTypesClass(es) back to be added to the interactable objects
+        // other mods can subscribe to this event and optionally pass InteractionAction(es) back to be added to the interactable objects
         public event ActionsAppliedEventHandler OnActionsAppliedEvent;
         public delegate OnActionsAppliedResult ActionsAppliedEventHandler(ExfiltrationPoint exfil, CustomExfilTrigger customExfilTrigger, bool exfilIsAvailableToPlayer);
         public bool DisableVanillaActions { get; set; } = false;
@@ -177,7 +178,7 @@ namespace InteractableExfilsAPI.Singletons
         /// Get the current prompt state for current player
         /// </summary>
         /// <returns></returns>
-        public static BindableStateClass<ActionsReturnClass> GetAvailableInteractionState()
+        public static BindableState<AvailableInteractionState> GetAvailableInteractionState()
         {
             var session = GetSession();
             if (session == null)


### PR DESCRIPTION
DRAFT until I finish local testing.

- Rename classes for SPT 4.1 -- change in public API to match the new deobfuscated names, maybe not desired, deferring to @Jehree !
- Make `GetAvailableActionsPatch` safer with a failing-at-compile-time delegate cast.